### PR TITLE
Bump rules_docker to 0.25.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,9 +27,8 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
-    strip_prefix = "rules_docker-0.14.4",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
+    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
@@ -56,10 +55,6 @@ container_repositories()
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
-
-load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
-
-pip_deps()
 
 # See: https://github.com/bazelbuild/rules_docker#go_image
 


### PR DESCRIPTION
At current HEAD, running `bazel run //cmd/simulator:simulator` gives the error

```
ERROR: /home/joon/.cache/bazel/_bazel_joon/9c9f4b45750f8adb97f0298f4dc9193a/external/bazel_tools/platforms/BUILD:59:6: in alias rule @bazel_tools//platforms:osx: Constraints from @bazel_tools//platforms have been removed. Please use constraints from @platforms repository embedded in Bazel, or preferably declare dependency on https://github.com/bazelbuild/platforms. See https://github.com/bazelbuild/bazel/issues/8622 for details.
ERROR: /home/joon/.cache/bazel/_bazel_joon/9c9f4b45750f8adb97f0298f4dc9193a/external/bazel_tools/platforms/BUILD:59:6: Analysis of target '@bazel_tools//platforms:osx' failed
ERROR: /home/joon/Projects/simhospital/cmd/simulator/BUILD.bazel:38:10: While resolving toolchains for target //cmd/simulator:simulator: invalid registered toolchain '@io_bazel_rules_docker//toolchains/docker:default_osx_toolchain': 
ERROR: Analysis of target '//cmd/simulator:simulator' failed; build aborted: 
INFO: Elapsed time: 1.533s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (2 packages loaded, 0 targets configured)
ERROR: Build failed. Not running target
```

Updating the version of `rules_docker` fixes this.

This also means we can remove `pip_deps` (see https://github.com/bazelbuild/rules_docker/pull/1657).