### PR TITLE
Add PV1 placeholder for hardcoded HL7 messages

### DIFF
--- a/pkg/hospital/event_types.go
+++ b/pkg/hospital/event_types.go
@@ -777,7 +777,7 @@ func (h *Hospital) trackArrival(e *state.Event, logLocal *logging.SimulatedHospi
 func (h *Hospital) hardcodedMessage(e *state.Event, logLocal *logging.SimulatedHospitalLogger, now time.Time) error {
 	patientInfo := h.patients.Get(e.PatientMRN).PatientInfo
 	toIncludeRegex := e.Step.HardcodedMessage.Regex
-	msg, err := h.hardcodedMessageManager.Message(toIncludeRegex, patientInfo.Person, now)
+	msg, err := h.hardcodedMessageManager.Message(toIncludeRegex, patientInfo, now)
 	if err != nil {
 		return errors.Wrap(err, "cannot process HardcodedMessage event")
 	}


### PR DESCRIPTION
This commit adds a new placeholder for hardcoded HL7 messages, `PV1_SEGMENT_PLACEHOLDER`, that will insert a PV1 segment with information about the patient's current visit. This will be convenient when adding additional hardcoded messages that need to reference the patient's visit.